### PR TITLE
Pp/cpc ctc stats

### DIFF
--- a/cpc/criterion/criterion.py
+++ b/cpc/criterion/criterion.py
@@ -248,7 +248,7 @@ class CPCUnsupersivedCriterion(BaseCriterion):
                 assert o in ('pred',)
             captureRes = {}
             if 'pred' in captureOptions:
-                captureRes['pred'] = predictions.cpu()
+                captureRes['pred'] = predictions
 
         outLosses = [0 for x in range(self.nPredicts)]
         outAcc = [0 for x in range(self.nPredicts)]

--- a/cpc/criterion/criterion.py
+++ b/cpc/criterion/criterion.py
@@ -222,7 +222,7 @@ class CPCUnsupersivedCriterion(BaseCriterion):
 
         return "orthoLoss", self.orthoLoss * self.wPrediction.orthoCriterion()
 
-    def forward(self, cFeature, encodedData, label):
+    def forward(self, cFeature, encodedData, label, captureOptions):
 
         if self.mode == "reverse":
             encodedData = torch.flip(encodedData, [1])
@@ -242,6 +242,14 @@ class CPCUnsupersivedCriterion(BaseCriterion):
 
         predictions = self.wPrediction(cFeature, sampledData)
 
+        captureRes = None
+        if captureOptions != None:
+            for o in captureOptions:
+                assert o in ('pred',)
+            captureRes = {}
+            if 'pred' in captureOptions:
+                captureRes['pred'] = predictions.cpu()
+
         outLosses = [0 for x in range(self.nPredicts)]
         outAcc = [0 for x in range(self.nPredicts)]
 
@@ -254,7 +262,8 @@ class CPCUnsupersivedCriterion(BaseCriterion):
             outAcc[k] += torch.sum(predsIndex == labelLoss).float().view(1, -1)
 
         return torch.cat(outLosses, dim=1), \
-            torch.cat(outAcc, dim=1) / (windowSize * batchSize)
+            torch.cat(outAcc, dim=1) / (windowSize * batchSize), \
+                captureRes
 
 
 class SpeakerCriterion(BaseCriterion):

--- a/cpc/criterion/soft_align.py
+++ b/cpc/criterion/soft_align.py
@@ -329,8 +329,8 @@ class CPCUnsupersivedCriterion(BaseCriterion):
                 assert o in ('pred', 'align')
             captureRes = {}
             if 'pred' in captureOptions:
-                # need to remove 'predict self loop' stuff from captured data
-                captureRes['pred'] = predictions[:,:,:,1:]
+                # 1st sting in last dim can be self loop - need to keep as it's also being aligned
+                captureRes['pred'] = predictions
             if 'align' in captureOptions:
                 readableAligns = aligns.view(batchSize, windowSize, self.nMatched)
                 captureRes['align'] = readableAligns

--- a/cpc/criterion/soft_align.py
+++ b/cpc/criterion/soft_align.py
@@ -330,9 +330,9 @@ class CPCUnsupersivedCriterion(BaseCriterion):
             captureRes = {}
             if 'pred' in captureOptions:
                 # need to remove 'predict self loop' stuff from captured data
-                captureRes['pred'] = predictions[:,:,:,1:].cpu()
+                captureRes['pred'] = predictions[:,:,:,1:]
             if 'align' in captureOptions:
                 readableAligns = aligns.view(batchSize, windowSize, self.nMatched)
-                captureRes['align'] = readableAligns.cpu()
+                captureRes['align'] = readableAligns
 
         return losses, outAcc, captureRes

--- a/cpc/criterion/soft_align.py
+++ b/cpc/criterion/soft_align.py
@@ -238,7 +238,7 @@ class CPCUnsupersivedCriterion(BaseCriterion):
 
         # return outputs, labelLoss
 
-    def forward(self, cFeature, encodedData, label):
+    def forward(self, cFeature, encodedData, label, captureOptions):
 
         if self.mode == "reverse":
             encodedData = torch.flip(encodedData, [1])
@@ -308,4 +308,16 @@ class CPCUnsupersivedCriterion(BaseCriterion):
         outLossesD = outLosses.detach()
         losses = losses.mean() / outLossesD.sum() * outLossesD
 
-        return losses, outAcc
+        captureRes = None
+        if captureOptions != None:
+            for o in captureOptions:
+                assert o in ('pred', 'align')
+            captureRes = {}
+            if 'pred' in captureOptions:
+                # need to remove 'predict self loop' stuff from captured data
+                captureRes['pred'] = predictions[:,:,:,1:].cpu()
+            if 'align' in captureOptions:
+                readableAligns = aligns.view(batchSize, windowSize, self.nMatched)
+                captureRes['align'] = readableAligns.cpu()
+
+        return losses, outAcc, captureRes

--- a/cpc/dataset.py
+++ b/cpc/dataset.py
@@ -248,14 +248,12 @@ class AudioBatchData(Dataset):
                                    at the begining of each iteration
         """
         nLoops = len(self.packageIndex)
-        print("!!!!", self.totSize, self.sizeWindow, batchSize)
         totSize = self.totSize // (self.sizeWindow * batchSize)
         if onLoop >= 0:
             self.currentPack = onLoop - 1
             self.loadNextPack()
             nLoops = 1
 
-        print("!!!!!!!!!! SAMPLER TYPE", type)
         def samplerCall():
             offset = random.randint(0, self.sizeWindow // 2) \
                 if randomOffset else 0

--- a/cpc/train.py
+++ b/cpc/train.py
@@ -335,8 +335,8 @@ def run(performTraining,
         
         captureLoader = captureDataset.getDataLoader(batchSize, 'sequential', False,
                                                 numWorkers=0)
-        print(f"Capturing data for epoch {startEpoch}")
-        captureStep(captureLoader, cpcModel, cpcCriterion, captureOptions, startEpoch)
+        print(f"Capturing data for model checkpoint after epoch: {startEpoch-1}")
+        captureStep(captureLoader, cpcModel, cpcCriterion, captureOptions, startEpoch-1)
 
 
 def main(args):


### PR DESCRIPTION
Added option to capture data for future visualizations (save them across different epochs during training, or just see what is produced after the training) - representations, CPC predictions and CPC-CTC alignments

Example run that saves data each 2 epochs for 33% of provided 'capture dataset':
python train.py --pathDB /pio/scratch/1/i283340/MGR/zs/ds2 \
--pathTrain /pio/scratch/1/i283340/MGR/zs/sometries/ds2part.txt \
--pathVal /pio/scratch/1/i283340/MGR/zs/sometries/ds2part.txt \
--pathCaptureDS /pio/scratch/1/i283340/MGR/zs/sometries/ds2part.txt \
--captureDSfreq 33 --captureEachEpochs 2 \
--pathCaptureSave /pio/scratch/1/i283340/MGR/zs/capture/try2 \
--saveRepr --savePred --saveAlign \
--pathCheckpoint /pio/scratch/1/i283340/MGR/zs/checkpoints/cpcctc_tests2 \
--file_extension .flac --n_process_loader 2 --max_size_loaded 40000000 \
--batchSizeGPU 16 --nPredicts 8 --CPCCTC --CPCCTCNumMatched 12 \
--CPCCTCSelfLoop --CPCCTCSkipBeg 1 --CPCCTCSkipEnd 2